### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ bugs or is incomplete
 ## How to use the plugin
 
 1. Download latest IDEA Community Edition. In Settings>Plugins search for this one and install.
+1a. Be sure the Gradle plugin is enabled
 2. Create new project or open existing one
 3. Setup SDK and apply it to project
 4. Set target device etc


### PR DESCRIPTION
Adds a note to README.md to enable Gradle plugin

Attempting to use the Monkey C plugin in an IDEA installation with Gradle disabled resulted in "Error:Module 'hello_garmin' production: java.lang.NoClassDefFoundError: com/google/common/collect/FluentIterable"