### PR TITLE
Fix native linux support without wine

### DIFF
--- a/src/main/java/io/github/liias/monkey/Utils.java
+++ b/src/main/java/io/github/liias/monkey/Utils.java
@@ -1,9 +1,7 @@
 package io.github.liias.monkey;
 
-import com.google.common.collect.ImmutableList;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.SystemInfoRt;
 import com.intellij.openapi.vfs.CharsetToolkit;
 
 import java.util.ArrayList;
@@ -11,21 +9,6 @@ import java.util.List;
 
 public class Utils {
   public static GeneralCommandLine createGeneralCommandLine(String workDirectory, String exePath) {
-    if (SystemInfo.isLinux) {
-      // wine bla.exe
-      // wine cmd /c bla.bat
-      ImmutableList.Builder<String> paramsBuilder = ImmutableList.builder();
-      if (exePath.endsWith(".bat")) {
-        paramsBuilder.add("cmd", "/c");
-      }
-      paramsBuilder.add(exePath);
-      return new GeneralCommandLine()
-        .withWorkDirectory(workDirectory)
-        .withExePath("wine")
-        .withParameters(paramsBuilder.build())
-        .withCharset(CharsetToolkit.UTF8_CHARSET);
-    }
-
     if (SystemInfo.isMac) {
       String macExePath = exePath;
       List<String> parameters = new ArrayList<>();
@@ -48,14 +31,5 @@ public class Utils {
       .withWorkDirectory(workDirectory)
       .withExePath(exePath)
       .withCharset(CharsetToolkit.UTF8_CHARSET);
-  }
-
-  public static String getForWinLinOrMac(String winLin, String mac) {
-    if (SystemInfoRt.isWindows || SystemInfoRt.isLinux) {
-      return winLin;
-    } else if (SystemInfoRt.isMac) {
-      return mac;
-    }
-    throw new UnsupportedOperationException("OS is unsupported: " + SystemInfoRt.OS_NAME);
   }
 }

--- a/src/main/java/io/github/liias/monkey/ide/actions/appsettings/SimulatorCommunication.java
+++ b/src/main/java/io/github/liias/monkey/ide/actions/appsettings/SimulatorCommunication.java
@@ -15,6 +15,7 @@ import io.github.liias.monkey.deserializer.type.MonkeyType;
 import io.github.liias.monkey.deserializer.type.MonkeyTypeHash;
 import io.github.liias.monkey.project.dom.manifest.Manifest;
 import io.github.liias.monkey.project.module.util.MonkeyModuleUtil;
+import io.github.liias.monkey.project.sdk.SdkHelper;
 import io.github.liias.monkey.project.sdk.MonkeySdkType;
 import io.github.liias.monkey.project.sdk.tools.SimulatorHelper;
 import org.apache.sanselan.util.IOUtils;
@@ -32,7 +33,6 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.github.liias.monkey.Utils.createGeneralCommandLine;
-import static io.github.liias.monkey.Utils.getForWinLinOrMac;
 
 public class SimulatorCommunication {
   private static final Logger LOG = Logger.getInstance("#io.github.liias.monkey.ide.actions.appsettings.SimulatorCommunication");
@@ -142,8 +142,8 @@ public class SimulatorCommunication {
   }
 
   // with shell we can poll if simulator is running and ready
-  private GeneralCommandLine createShellCmd(int port, String outputDir, String command, String fromPath, String toPath) {
-    String shellExecutableName = getForWinLinOrMac("shell.exe", "shell");
+  private GeneralCommandLine createShellCmd(int port, String outputDir, String command, String fromPath, String toPath) throws ExecutionException {
+    String shellExecutableName = SdkHelper.get(SdkHelper.SHELL_CMD);
     String sdkBinPath = MonkeySdkType.getBinPath(sdk);
     String exePath = sdkBinPath + shellExecutableName;
 

--- a/src/main/java/io/github/liias/monkey/project/runconfig/AbstractMonkeyRunningState.java
+++ b/src/main/java/io/github/liias/monkey/project/runconfig/AbstractMonkeyRunningState.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl;
+import io.github.liias.monkey.project.sdk.SdkHelper;
 import io.github.liias.monkey.project.sdk.MonkeySdkType;
 import io.github.liias.monkey.project.sdk.tools.SimulatorHelper;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +33,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import static io.github.liias.monkey.Utils.createGeneralCommandLine;
-import static io.github.liias.monkey.Utils.getForWinLinOrMac;
 import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractMonkeyRunningState extends CommandLineState {
@@ -171,7 +171,7 @@ public abstract class AbstractMonkeyRunningState extends CommandLineState {
     final Sdk sdk = getMonkeyParameters().getSdk();
     String sdkBinPath = MonkeySdkType.getBinPath(sdk);
 
-    String simulatorExecutableName = getForWinLinOrMac("simulator.exe", "ConnectIQ.app");
+    String simulatorExecutableName = SdkHelper.get(SdkHelper.SIMULATOR_CMD);
     String exePath = sdkBinPath + simulatorExecutableName;
     return createGeneralCommandLine(sdkBinPath, exePath).withRedirectErrorStream(true);
   }
@@ -187,11 +187,14 @@ public abstract class AbstractMonkeyRunningState extends CommandLineState {
 
     Sdk sdk = monkeyParameters.getSdk();
 
-    GeneralCommandLine generalCommandLine = createGeneralCommandLine(MonkeySdkType.getBinPath(sdk), MonkeySdkType.getMonkeydoBatPath(sdk))
+    String sdkBinPath = MonkeySdkType.getBinPath(sdk);
+    String monkeydoExecutableName = SdkHelper.get(SdkHelper.MONKEYDO_CMD);
+    String exePath = sdkBinPath + monkeydoExecutableName;
+    GeneralCommandLine generalCommandLine = createGeneralCommandLine(sdkBinPath, exePath)
       .withParameters(prgPath, getConfiguration().getTargetDeviceId());
 
     if (isForTests()) {
-      generalCommandLine.addParameter(getForWinLinOrMac("/t", "-t"));
+      generalCommandLine.addParameter(SdkHelper.get(SdkHelper.MONKEYDO_TEST_PARAM));
       //if (testId != null) {
       //  generalCommandLine.addParameter(testId);
       //}

--- a/src/main/java/io/github/liias/monkey/project/sdk/MonkeySdkType.java
+++ b/src/main/java/io/github/liias/monkey/project/sdk/MonkeySdkType.java
@@ -23,8 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-import static io.github.liias.monkey.Utils.getForWinLinOrMac;
-
 public class MonkeySdkType extends SdkType {
   public static String COMPILER_INFO_XML = "compilerInfo.xml";
 
@@ -199,11 +197,6 @@ public class MonkeySdkType extends SdkType {
 
   @Override
   public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
-  }
-
-  public static String getMonkeydoBatPath(@NotNull Sdk sdk) {
-    String monkeydo = getForWinLinOrMac("monkeydo.bat", "monkeydo");
-    return getBinPath(sdk) + monkeydo;
   }
 
   public VirtualFile getBinDir(@NotNull Sdk sdk) {

--- a/src/main/java/io/github/liias/monkey/project/sdk/SdkHelper.java
+++ b/src/main/java/io/github/liias/monkey/project/sdk/SdkHelper.java
@@ -1,0 +1,52 @@
+package io.github.liias.monkey.project.sdk;
+
+import com.google.common.collect.ImmutableMap;
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.util.SystemInfoRt;
+import org.jetbrains.annotations.NotNull;
+
+public class SdkHelper {
+	public static final Integer MONKEYDO_CMD = 0;
+	public static final Integer MONKEYDO_TEST_PARAM =1;
+	public static final Integer SHELL_CMD = 2;
+	public static final Integer SIMULATOR_CMD = 3;
+
+	private static final ImmutableMap<Integer, String> linux = ImmutableMap.<Integer, String>builder()
+		.put(MONKEYDO_CMD, "monkeydo")
+		.put(MONKEYDO_TEST_PARAM, "-t")
+		.put(SHELL_CMD, "shell")
+		.put(SIMULATOR_CMD, "simulator")
+		.build();
+
+	private static final ImmutableMap<Integer, String> mac = ImmutableMap.<Integer, String>builder()
+		.put(MONKEYDO_CMD, "monkeydo")
+		.put(MONKEYDO_TEST_PARAM, "-t")
+		.put(SHELL_CMD, "shell")
+		.put(SIMULATOR_CMD, "ConnectIQ.app")
+		.build();
+
+	private static final ImmutableMap<Integer, String> win = ImmutableMap.<Integer, String>builder()
+		.put(MONKEYDO_CMD, "monkeydo.bat")
+		.put(MONKEYDO_TEST_PARAM, "/t")
+		.put(SHELL_CMD, "shell.exe")
+		.put(SIMULATOR_CMD, "simulator.exe")
+		.build();
+
+	@NotNull
+	public static String get(Integer cmd) throws ExecutionException {
+		if (SystemInfoRt.isWindows) {
+			if (win.containsKey(cmd))
+			return win.get(cmd);
+		} else if (SystemInfoRt.isLinux) {
+			if (linux.containsKey(cmd))
+				return linux.get(cmd);
+		} else if (SystemInfoRt.isMac) {
+			if (mac.containsKey(cmd))
+				return mac.get(cmd);
+		} else {
+			throw new ExecutionException("Unsupported OS " + SystemInfoRt.OS_NAME);
+		}
+		throw new ExecutionException("Unsupported CMD " + cmd);
+	}
+
+}

--- a/src/main/java/io/github/liias/monkey/project/sdk/tools/SimulatorHelper.java
+++ b/src/main/java/io/github/liias/monkey/project/sdk/tools/SimulatorHelper.java
@@ -5,6 +5,7 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.projectRoots.Sdk;
+import io.github.liias.monkey.project.sdk.SdkHelper;
 import io.github.liias.monkey.project.sdk.MonkeySdkType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,7 +17,6 @@ import java.io.InputStreamReader;
 import java.util.Optional;
 
 import static io.github.liias.monkey.Utils.createGeneralCommandLine;
-import static io.github.liias.monkey.Utils.getForWinLinOrMac;
 
 public class SimulatorHelper {
   public static final int SIMULATOR_PORT_MIN = 1234;
@@ -32,7 +32,7 @@ public class SimulatorHelper {
   @NotNull
   private final String outputDir;
 
-  public SimulatorHelper(@Nullable ConsoleView console, @NotNull Sdk sdk, @NotNull String outputDir) {
+  public SimulatorHelper(@Nullable ConsoleView console, @NotNull Sdk sdk, @NotNull String outputDir) throws ExecutionException {
     this.console = console;
     this.sdk = sdk;
     this.outputDir = outputDir;
@@ -69,8 +69,8 @@ public class SimulatorHelper {
   }
 
   // with shell we can poll if simulator is running and ready
-  private GeneralCommandLine createShellCmd(int port) {
-    String shellExecutableName = getForWinLinOrMac("shell.exe", "shell");
+  private GeneralCommandLine createShellCmd(int port) throws ExecutionException {
+    String shellExecutableName = SdkHelper.get(SdkHelper.SHELL_CMD);
     String sdkBinPath = MonkeySdkType.getBinPath(sdk);
     String exePath = sdkBinPath + shellExecutableName;
 


### PR DESCRIPTION
This pull request removes the wine dependency for linux. I also created an abstract sdk helper class, and then one for each os to keep all the os specific things in one place. It felt cleaner than having it in the rest of the code. Also, I only use Linux, so my changes is not tested with anything else, but I tried to keep the commands for windows and mac... so it SHOULD work... which most probably might indicate that it have a chance of working.... 
Anyway, on Linux I'm able to use the run button to test my watchface in a simulator with no wine installed. 

However, the Garmin Linux SDK is using VERY old deps
so, to get that to work you might need to find and setup
the dependencies manually. For Fedora 27/28 I setup the following libs:
libjavascriptcoregtk-1.0.so -> libjavascriptcoregtk-1.0.so.0.16.19
libjavascriptcoregtk-1.0.so.0 -> libjavascriptcoregtk-1.0.so.0.16.19
libjavascriptcoregtk-1.0.so.0.16.19
libjpeg.so.8 -> libjpeg.so.8.0.2
libjpeg.so.8.0.2
libwebkitgtk-1.0.so -> libwebkitgtk-1.0.so.0.22.17
libwebkitgtk-1.0.so.0 -> libwebkitgtk-1.0.so.0.22.17
libwebkitgtk-1.0.so.0.22.17

Fixes #12 